### PR TITLE
Markdown Editor compatible with Field: Multilingual Text Box

### DIFF
--- a/assets/symphony.markdown_editor.js
+++ b/assets/symphony.markdown_editor.js
@@ -110,7 +110,7 @@ $.MarkdownEditor = function(element, options){
 
 	if (!$textarea.is('textarea')) debug('You can only call this plugin on textareas!');
 
-	$field = $textarea.closest('.field');
+	$field = $textarea.closest('div');
 	editor.settings = {};
 
 	editor.init = function() {


### PR DESCRIPTION
Hello Jonas,

I started to use Github yesterday, so I’m a bit fumbling in the dark to pull this commit – I’ve no idea if this is the right modus operani for suggesting changes either, so please excuse my noobness.

I wanted to use your nice and synthetic Markdown Editor in combination with the Field: Multilingual Text Box, but the former was messing up the interface when installed:

http://www.andreaburan.com/workspace/files/markdown_editor_messed_up_interface_00.jpg

I dig a little in your code, I changed only a single line and after that the editor works properly. I tested it quickly in the default workspace of Symphony and it was working fine also for the standard textarea.
